### PR TITLE
Add support for the DISPLAY env var

### DIFF
--- a/src/main.odin
+++ b/src/main.odin
@@ -8,6 +8,7 @@ import "core:mem"
 import "core:os"
 import "core:path/filepath"
 import "core:slice"
+import "core:strings"
 import "core:sys/linux"
 import "core:testing"
 
@@ -231,7 +232,9 @@ connect_x11_socket :: proc() -> os.Socket {
 	socket, err := os.socket(os.AF_UNIX, os.SOCK_STREAM, 0)
 	assert(err == os.ERROR_NONE)
 
-	possible_socket_paths := [2]string{"/tmp/.X11-unix/X0", "/tmp/.X11-unix/X1"}
+	display_env := strings.trim_left(os.get_env("DISPLAY"), ":")
+	display_socket := strings.concatenate([]string{"/tmp/.X11-unix/X", display_env})
+	possible_socket_paths := [3]string{display_socket, "/tmp/.X11-unix/X0", "/tmp/.X11-unix/X1"}
 	for &socket_path in possible_socket_paths {
 		addr := SockaddrUn {
 			sa_family = cast(u16)os.AF_UNIX,


### PR DESCRIPTION
When trying to connect to the X server, check `$DISPLAY`, and construct a path from it.

I'm using Wayland, with a compositor (niri) that does not support XWayland itself, so I am using a separate program (xwayland-satellite) to provide XWayland support, and for various reasons, I chose to run it on display `:42`. I was slightly disappointed when the game didn't launch for me, even though I set `DISPLAY=:42`, but it ran fine if I put an XWayland server on `:0`. So I poked at the code a little, and after a few quick glances at the Odin docs, I came up with this little patch.

It's likely not very idiomatic, but it gets the job done: the game works both with `DISPLAY=:42`, and without `DISPLAY` unset too (if there's an X server on :0 or :1), and also falls back to `:0` or `:1` when given an incorrect `$DISPLAY`. The `DISPLAY` parsing is very naive: it just removes the first character if it is `:`, and appends the rest to the `/tmp/.X11-unix/X` prefix. I felt that for the purpose of the game, this is fine.